### PR TITLE
Test進行ブランチ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 /.gradle/
 
 # IntelliJ project files
-.idea/
 .idea/shelf/
 .idea/workspace.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 
 # IntelliJ project files
 .idea/
-*.iml
+.idea/shelf/
+.idea/workspace.xml
 
 # Logs
 *.log

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="JavadocBlankLines" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LossyEncoding" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="NonAsciiCharacters" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/src/main/java/student/management/Student/Management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/student/management/Student/Management/exception/GlobalExceptionHandler.java
@@ -33,7 +33,6 @@ public class GlobalExceptionHandler {
   /**
    * 独自例外用
    * アプリケーション内で発生する業務的な例外 {@link MyException} を処理します。
-   *
    * この例外は、バリデーションやビジネスロジック上の明示的なエラーで使用され、
    * クライアントには HTTP 400（Bad Request） として返却されます。
    *
@@ -49,7 +48,6 @@ public class GlobalExceptionHandler {
   /**
    * 予期しないエラー用
    * アプリケーションで発生した予期しない例外（全ての {@link Exception}）を処理します。
-   *
    * ログ出力や通知の対象となり得る、開発者の想定外の例外です。
    * クライアントには一般的なエラーメッセージと HTTP 500（内部サーバーエラー）を返却します。
    *

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -127,5 +127,6 @@ class StudentServiceTest {
     // Assert（検証）: リポジトリのメソッドが正しく呼び出されたかを確認
     verify(repository).updateStudent(student);
     verify(repository).updateStudentCourse(course);
+
   }
 }

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -128,5 +128,4 @@ class StudentServiceTest {
     verify(repository).updateStudent(student);
     verify(repository).updateStudentCourse(course);
   }
-
 }

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -60,7 +60,6 @@ class StudentServiceTest {
 
   @Test
   void 受講生の詳細検索_IDに基づいて受講生とコースを取得し詳細を返すこと() {
-
     //Arrange（準備）: モックが返す受講生とコースを定義
     Student student = new Student();
     student.setId("999");
@@ -84,7 +83,6 @@ class StudentServiceTest {
 
   @Test
   void 受講生登録_受講生と受講生コースが適切に登録されること() {
-
     //Arrange（準備）: テストの対象となる受講生と受講生コース情報を定義
     Student student = new Student();
     student.setId("999");
@@ -113,7 +111,6 @@ class StudentServiceTest {
 
   @Test
   void 受講生更新_受講生とコース情報の更新が実行されること(){
-
     // Arrange（準備）: 受講生と複数の受講生コース情報を用意
     Student student = new Student();
     StudentCourse course = new StudentCourse();


### PR DESCRIPTION
### **実装内容**

行ったこと
・受講生一覧検索、受講生詳細検索、受講生登録、受講生更新の４つのTestをServiceTestに実装

テストのスクリーンショット計4枚

<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 17 57" src="https://github.com/user-attachments/assets/7668be6f-d57a-49f9-b0a1-24540cd3f2b2" />
<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 17 14" src="https://github.com/user-attachments/assets/2f4e9e5e-5954-4375-95f9-584817ef2544" />
<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 17 00" src="https://github.com/user-attachments/assets/b3bba714-0c55-429e-b793-e390510e1677" />
<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 16 43" src="https://github.com/user-attachments/assets/1da283ea-ada6-481f-a4f0-089409a6139f" />


工夫した点・学んだこと
・テストコードにおけるwhenとverifyがイコールになっている点とテストだからだと思いますが、Serviceクラスとの関連性がよく見える物だったので他のTestもこんな感じなのかなと想像が膨らみました。
・きちんと動く間接的な検証を入れたが、他に別の記載方法があるのでは？と思い、Javaひいてはプログラムは奥が深いなと感じました。

反省点
・gitignoreを消していて、前回提出時は不必要なファイルがたくさん含まれていた。
・今回はgitignoreが反映されて綺麗な状態となっていると思います。

変更差分について
・前回提出した際は、REST化進行ブランチで提出しましたが、新たなブランチ(Test進行ブランチ)にしたこととmainにマージした際の元のブランチ(REST化進行ブランチ)もStudentServiceTestの実装をした後のものだったため、変更差分という変更差分が恐らくありません。理由としては強制的にPRを出すために空白の行の増減を行なったためです。
