### PR TITLE
StudentControllerTESTの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 /.gradle/
 
 # IntelliJ project files
-.idea/
 .idea/shelf/
 .idea/workspace.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 
 # IntelliJ project files
 .idea/
-*.iml
+.idea/shelf/
+.idea/workspace.xml
 
 # Logs
 *.log

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="JavadocBlankLines" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LossyEncoding" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="NonAsciiCharacters" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
     //便利機能、ユーティリティ
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
+	implementation 'org.apache.commons:commons-lang3:3.18.0'
 
     //Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/student/management/Student/Management/controller/StudentController.java
+++ b/src/main/java/student/management/Student/Management/controller/StudentController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -52,8 +51,10 @@ public class StudentController {
   })
 
   @GetMapping ("/student/{id}")
-  public StudentDetail getStudent(
-      @PathVariable @Valid @Size(min = 1,max = 3) String id){
+  public StudentDetail getStudent(@PathVariable  String id) {
+    if (id.length() >3){
+      throw new MyException("IDは３文字以内で入力してください。");
+    }
     return service.searchStudent(id);
   }
 

--- a/src/main/java/student/management/Student/Management/data/Student.java
+++ b/src/main/java/student/management/Student/Management/data/Student.java
@@ -7,12 +7,15 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 //Studentのデータ　カラム名に依存
-
 @Schema(description = "受講生情報")
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 public class Student {

--- a/src/main/java/student/management/Student/Management/data/StudentCourse.java
+++ b/src/main/java/student/management/Student/Management/data/StudentCourse.java
@@ -3,12 +3,16 @@ package student.management.Student.Management.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 //Studentコースのデータ　カラム名に依存
 
 @Schema(description = "受講生コース情報")
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 public class StudentCourse {

--- a/src/main/java/student/management/Student/Management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/student/management/Student/Management/exception/GlobalExceptionHandler.java
@@ -33,7 +33,6 @@ public class GlobalExceptionHandler {
   /**
    * 独自例外用
    * アプリケーション内で発生する業務的な例外 {@link MyException} を処理します。
-   *
    * この例外は、バリデーションやビジネスロジック上の明示的なエラーで使用され、
    * クライアントには HTTP 400（Bad Request） として返却されます。
    *
@@ -49,7 +48,6 @@ public class GlobalExceptionHandler {
   /**
    * 予期しないエラー用
    * アプリケーションで発生した予期しない例外（全ての {@link Exception}）を処理します。
-   *
    * ログ出力や通知の対象となり得る、開発者の想定外の例外です。
    * クライアントには一般的なエラーメッセージと HTTP 500（内部サーバーエラー）を返却します。
    *

--- a/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
+++ b/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
@@ -117,7 +117,7 @@ class StudentControllerTest {
         "北海道",
         33,
         "女性",
-        " ",
+        "備考",
         false
     );
 
@@ -138,7 +138,7 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.student.region").value("北海道"))
         .andExpect(jsonPath("$.student.age").value(33))
         .andExpect(jsonPath("$.student.gender").value("女性"))
-        .andExpect(jsonPath("$.student.remark").value(" "))
+        .andExpect(jsonPath("$.student.remark").value("備考"))
         .andExpect(jsonPath("$.student.deleted").value(false));
   }
 

--- a/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
+++ b/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
@@ -39,8 +39,9 @@ class StudentControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
-  @SuppressWarnings({"removal",})
+  @SuppressWarnings({"removal"})
 
+  //Repositoryをモック化
   @MockBean
   private StudentRepository repository;
 
@@ -52,10 +53,11 @@ class StudentControllerTest {
   @DisplayName("正常系：受講生一覧を取得し、空のリストが返ること")
   void 受講生詳細_一覧検索ができて空のリストが返ってくること() throws Exception {
 
+    //Arrange : モック設定で空のリストを返す
     when(repository.search()).thenReturn(List.of());
     when(repository.searchStudentCourseList()).thenReturn(List.of());
 
-    //Act & Assert : GETリクエストを実行し、ステータス200とサービス呼び出し回数を検証
+    //Act & Assert : GETリクエストを実行し、からのリストが返ってくることを検証
     mockMvc.perform(get("/studentList"))
         .andExpect(status().isOk())
         .andExpect(content().json("[]"));
@@ -82,13 +84,14 @@ class StudentControllerTest {
     //Act : バリデーションの実行
     Set<ConstraintViolation<Student>> violations = validator.validate(student);
 
-    //Assert : エラー件数が0であることを検証
+    //Assert : エラー件数が0件であることを検証
     Assertions.assertEquals(0, violations.size());
   }
 
   @Test
   @DisplayName("異常系：受講生IDに不正な文字列を入力するとバリデーションエラーが発生する")
   void 受講生詳細_受講生でIDに数字以外が入力された時に入力チェックがかかること() {
+
     //Arrange : 不正なIDをセット
     Student student = new Student();
     student.setId("テストです");
@@ -120,6 +123,7 @@ class StudentControllerTest {
 
     List<StudentCourse> courseList = List.of();
 
+    // Arrange : ID=1 に対応する受講生とそのコース情報をモック設定
     when(repository.searchStudent("1")).thenReturn(student);
     when(repository.searchStudentCourse("1")).thenReturn(courseList);
 
@@ -141,6 +145,7 @@ class StudentControllerTest {
   @Test
   @DisplayName("異常系：存在しないIDを指定するとMyExceptionが返る")
   void 受講生詳細_存在しないIDを指定するとMyExceptionが返ること() throws Exception {
+
     // Arrange：例外をスローするようモック設定
     when(repository.searchStudent("999")).thenThrow(new MyException("存在しないIDです。"));
 
@@ -153,6 +158,7 @@ class StudentControllerTest {
   @Test
   @DisplayName("異常系：IDの桁数超過により400エラーが返る")
   void 受講生詳細_IDが長すぎる場合は400が返ってくること() throws Exception {
+
     // Act & Assert：GET /exception 実行で例外ハンドリングを確認
     mockMvc.perform(get("/student/9999"))
         .andExpect(status().isBadRequest());
@@ -186,7 +192,7 @@ class StudentControllerTest {
   }
   """;
 
-    // Arrange :
+    // Arrange :　登録処理を正常に通過させるため、例外をスローしないようにモック設定
     doNothing().when(repository).registerStudent(any());
 
     // Act & Assert : 登録APIに対してPOSTリクエストを送信し、HTTPステータス200（OK）が返されることを検証
@@ -208,7 +214,7 @@ class StudentControllerTest {
       "fullname": "高橋一美",
       "furigana": "たかはしかずみ",
       "nickname": "かみ",
-      "email": "takahasi@examplecom",
+      "email": "メールアドレス",
       "region": "北海道",
       "gender": "女性",
       "age": 33,
@@ -223,7 +229,7 @@ class StudentControllerTest {
   }
   """;
 
-    // Arrange : サービス層で MyException をスローするようモック設定
+    // Arrange : repository の registerStudent 呼び出し時に MyException をスローするようモック設定
     doThrow(new MyException("登録失敗")).when(repository).registerStudent(any());
 
     //Act & Assert : 登録APIをPOSTリクエストで呼び出し、HTTP 400 BadRequest が返されることを検証
@@ -295,7 +301,7 @@ class StudentControllerTest {
     ]
   }
   """;
-
+    //Arrange : 更新処理時に MyException をスローするよう repository をモック
     doThrow(new MyException("更新失敗")).when(repository).updateStudent(any());
 
     //Act & Assert : 更新APIに対してPUTリクエストを送信し、HTTPステータス400（Bad Request）とメッセージ「更新失敗」が返ることを検証

--- a/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
+++ b/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
@@ -18,6 +18,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -44,22 +45,23 @@ class StudentControllerTest {
   @SuppressWarnings("resource")
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-  // 一覧取得（正常系）
   @Test
+  @DisplayName("正常系：受講生一覧を取得し、空のリストが返ること")
   void 受講生詳細_一覧検索ができて空のリストが返ってくること() throws Exception {
-    //Act & Assert
+
+    //Act & Assert : GETリクエストを実行し、ステータス200とサービス呼び出し回数を検証
     mockMvc.perform(get("/studentList"))
         .andExpect(status().isOk());
 
     verify(service, times(1)).searchStudentList();
   }
 
-  // バリデーション(正常系)
   @Test
+  @DisplayName("正常系：受講生に適切な値を入力するとバリデーションエラーが発生しない")
   void 受講生詳細_受講生で適切な値を入力したときに入力チェックに異常が発生しないこと() {
     Student student = new Student();
 
-    //Arrange : バリデーション対応項目と値
+    //Arrange : 正しい項目値をセット
     student.setId("1");
     student.setFullname("高橋一美");
     student.setFurigana("たかはしかずみ");
@@ -69,31 +71,32 @@ class StudentControllerTest {
     student.setGender("女性");
     student.setAge(33);
 
-    //Act
+    //Act : バリデーションの実行
     Set<ConstraintViolation<Student>> violations = validator.validate(student);
 
-    //Assert
+    //Assert : エラー件数が0であることを検証
     Assertions.assertEquals(0, violations.size());
   }
 
-  // バリデーション(異常系)
   @Test
+  @DisplayName("異常系：受講生IDに不正な文字列を入力するとバリデーションエラーが発生する")
   void 受講生詳細_受講生でIDに数字以外が入力された時に入力チェックがかかること() {
+    //Arrange : 不正なIDをセット
     Student student = new Student();
     student.setId("テストです");
 
-    //Act
+    //Act : バリデーションを実行
     Set<ConstraintViolation<Student>> violations = validator.validate(student);
 
-    //Assert
+    //Assert : エラー件数が期待値と一致することを検証
     Assertions.assertEquals(7, violations.size());
   }
 
-  //個別取得(正常系)
   @Test
+  @DisplayName("正常系：ID指定で受講生詳細が取得できること")
   void 受講生詳細_IDを指定することで受講生情報が返ること() throws Exception {
 
-    //Arrange
+    //Arrange ： サービスの戻り値を設定
     Student student = new Student();
     student.setId("1");
     student.setFullname("高橋一美");
@@ -103,36 +106,39 @@ class StudentControllerTest {
 
     given(service.searchStudent("1")).willReturn(detail);
 
-    //Act & Assert
+    //Act & Assert ： GET実行後のレスポンスを検証
     mockMvc.perform(get("/student/{id}", "1"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.student.id").value("1"))
         .andExpect(jsonPath("$.student.fullname").value("高橋一美"));
   }
 
-  //個別取得(異常系)
   @Test
+  @DisplayName("異常系：存在しないIDを指定するとMyExceptionが返る")
   void 受講生詳細_存在しないIDを指定するとMyExceptionが返ること() throws Exception {
-
+    // Arrange：例外をスローするようモック設定
     given(service.searchStudent("999")).willThrow(new MyException("存在しないIDです。"));
+
+    // Act & Assert：GET時に400エラーとメッセージを検証
     mockMvc.perform(get("/student/999"))
         .andExpect(status().isBadRequest())
         .andExpect(content().string("存在しないIDです。"));
   }
 
-  // IDの形式不正（桁数制限など）で400エラーが返ることを確認
   @Test
+  @DisplayName("異常系：IDの桁数超過により400エラーが返る")
   void 受講生詳細_IDが長すぎる場合は400が返ってくること() throws Exception {
+    // Act & Assert：GET /exception 実行で例外ハンドリングを確認
     mockMvc.perform(get("/student/9999"))
         .andExpect(status().isBadRequest());
+
   }
 
-  // 登録（正常系）
-  // 正しいStudentDetailを渡すと200 OKが返る
   @Test
+  @DisplayName("正常系：正しい入力で受講生登録が成功すること")
   void 受講生登録_正しい入力で登録が成功すること() throws Exception {
 
-    //Arrange
+    //Arrange ： 登録用の正常なリクエストボディ（JSON）
     String json = """
   {
     "student": {
@@ -149,26 +155,27 @@ class StudentControllerTest {
     },
     "studentCourseList": [
       {
-        "courseName": "デザインコース"
+        "courseName": "WM"
       }
     ]
   }
   """;
 
+    // Arrange : MockしたStudentService が正常に登録処理を行い、空のStudentDetailを返すように設定
     given(service.registerStudent(any())).willReturn(new StudentDetail());
 
-    // Act & Assert
+    // Act & Assert : 登録APIに対してPOSTリクエストを送信し、HTTPステータス200（OK）が返されることを検証
     mockMvc.perform(post("/registerStudent")
             .contentType(MediaType.APPLICATION_JSON)
             .content(json))
         .andExpect(status().isOk());
   }
 
-  // 登録（異常系）
   @Test
+  @DisplayName("異常系：登録時にMyExceptionが発生すると400エラーが返る")
   void 受講生登録_サービスでMyExceptionが発生した場合400番エラーが返ること() throws Exception {
 
-    //Arrange
+    //Arrange : バリデーションエラー用の不正なJSON（メール形式不正）
     String json = """
   {
     "student": {
@@ -176,7 +183,7 @@ class StudentControllerTest {
       "fullname": "高橋一美",
       "furigana": "たかはしかずみ",
       "nickname": "かみ",
-      "email": "takahasi@example.com",
+      "email": "takahasi@examplecom",
       "region": "北海道",
       "gender": "女性",
       "age": 33,
@@ -191,10 +198,11 @@ class StudentControllerTest {
   }
   """;
 
+    // Arrange : サービス層で MyException をスローするようモック設定
     given(service.registerStudent(any()))
         .willThrow(new MyException("登録失敗"));
 
-    //Act & Assert
+    //Act & Assert : 登録APIをPOSTリクエストで呼び出し、HTTP 400 BadRequest が返されることを検証
     mockMvc.perform(post("/registerStudent")
             .contentType(MediaType.APPLICATION_JSON)
             .content(json))
@@ -202,11 +210,11 @@ class StudentControllerTest {
 
   }
 
-  // 更新（正常系）
   @Test
+  @DisplayName("正常系：受講生情報の更新が成功すること")
   void 受講生更新_正しい入力で更新成功すること()throws Exception{
 
-    //Arrange
+    //Arrange ： 更新用の正常なリクエストボディ（JSON）
     String json = """
   {
     "student": {
@@ -223,13 +231,13 @@ class StudentControllerTest {
     },
     "studentCourseList": [
       {
-        "courseName": "デザインコース"
+        "courseName": "WM"
       }
     ]
   }
   """;
 
-    //Act & Assert
+    //Act & Assert : 更新APIに対して PUT リクエストを送信し、HTTPステータス200（OK）と「更新処理が成功しました。」というメッセージが返ることを検証
     mockMvc.perform(put("/updateStudent")
             .contentType(MediaType.APPLICATION_JSON)
             .content(json))
@@ -237,11 +245,11 @@ class StudentControllerTest {
         .andExpect(content().string(containsString("更新処理が成功しました。")));
   }
 
-  // 更新（異常系）
   @Test
+  @DisplayName("異常系：更新時にMyExceptionが発生すると400エラーが返る")
   void 受講生更新_サービスでMyExceptionが発生した場合400番エラーが返ってくること()throws Exception{
 
-    //Arrange
+    //Arrange : 更新用のJSONリクエストと、ServiceがMyExceptionをスローするモック設定
     String json = """
   {
     "student": {
@@ -266,7 +274,7 @@ class StudentControllerTest {
 
     doThrow(new MyException("更新失敗")).when(service).updateStudent(any());
 
-    //Act & Assert
+    //Act & Assert : 更新APIに対してPUTリクエストを送信し、HTTPステータス400（Bad Request）とメッセージ「更新失敗」が返ることを検証
     mockMvc.perform(put("/updateStudent")
         .contentType(MediaType.APPLICATION_JSON)
         .content(json))
@@ -275,9 +283,10 @@ class StudentControllerTest {
 
   }
 
-  // 例外発生のシミュレーション（テスト用）
   @Test
+  @DisplayName("異常系：例外発生時に400エラーが返る")
   void 例外テストポイント_例外が発生して400番エラーが返ること()throws Exception{
+    // Act & Assert：GET /exception 実行で例外ハンドリングを確認
     mockMvc.perform(get("/exception"))
         .andExpect(status().isBadRequest())
         .andExpect(content().string("これはテスト用の例外です。"));

--- a/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
+++ b/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
@@ -1,7 +1,101 @@
 package student.management.Student.Management.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import student.management.Student.Management.data.Student;
+import student.management.Student.Management.domein.StudentDetail;
+import student.management.Student.Management.service.StudentService;
+
+@WebMvcTest(StudentController.class)
 class StudentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @SuppressWarnings("removal")
+  @MockBean
+  private StudentService service;
+
+  @SuppressWarnings("resource")
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  // 一覧取得（正常系）
+  // 受講生一覧の取得APIで 200 OK が返り、service が1回呼ばれることを確認
+  @Test
+  void 受講生詳細_一覧検索ができて空のリストが返ってくること() throws Exception{
+
+    mockMvc.perform(get("/studentList"))
+        .andExpect(status().isOk()) ;
+
+    verify(service, times(1)).searchStudentList();
+  }
+
+  // バリデーション正常系
+  // Studentエンティティの各項目に適切な値を設定したとき、バリデーション違反が発生しないことを確認
+  @Test
+  void 受講生詳細_受講生で適切な値を入力したときに入力チェックに異常が発生しないこと(){
+    Student student = new Student();
+
+    //バリデーション対応項目と値
+    student.setId("1");
+    student.setFullname("高橋一美");
+    student.setFurigana("たかはしかずみ");
+    student.setNickname("かみ");
+    student.setEmail("takahasi@example.com");
+    student.setRegion("北海道");
+    student.setGender("女性");
+    student.setAge(33);
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    Assertions.assertEquals(0, violations.size());
+  }
+
+  // バリデーション異常
+  // Studentエンティティに不正なID（数字以外）を設定したとき、バリデーション違反が発生することを確認
+  @Test
+  void 受講生詳細_受講生でIDに数字以外が入力された時に入力チェックがかかること(){
+    Student student = new Student();
+        student.setId("テストです");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    Assertions.assertEquals(7, violations.size());
+  }
+
+  //個別取得(正常)
+  //StudentにIDとフルネームを設定し、それをテスト用に用意したdetailに返す。
+  @Test
+  void 受講生詳細_IDを指定することで受講生情報が帰ること()throws Exception{
+    Student student = new Student();
+    student.setId("1");
+    student.setFullname("高橋一美");
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+
+    given(service.searchStudent("1")).willReturn(detail);
+
+    mockMvc.perform(get("/student/{id}","1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.student.id").value("1"))
+        .andExpect(jsonPath("$.student.fullname").value("高橋一美"));
+  }
+  //個別取得(異常系)
 
 }

--- a/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
+++ b/src/test/java/student/management/Student/Management/controller/StudentControllerTest.java
@@ -1,11 +1,14 @@
 package student.management.Student.Management.controller;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -33,20 +36,22 @@ class StudentControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
+  // StudentServiceのMockをDI。Controller単体テストのため。
   @SuppressWarnings("removal")
   @MockBean
   private StudentService service;
 
+  // バリデーションチェック用のValidatorインスタンス生成
   @SuppressWarnings("resource")
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
   // 一覧取得（正常系）
   // 受講生一覧の取得APIで 200 OK が返り、service が1回呼ばれることを確認
   @Test
-  void 受講生詳細_一覧検索ができて空のリストが返ってくること() throws Exception{
+  void 受講生詳細_一覧検索ができて空のリストが返ってくること() throws Exception {
 
     mockMvc.perform(get("/studentList"))
-        .andExpect(status().isOk()) ;
+        .andExpect(status().isOk());
 
     verify(service, times(1)).searchStudentList();
   }
@@ -54,7 +59,7 @@ class StudentControllerTest {
   // バリデーション正常系
   // Studentエンティティの各項目に適切な値を設定したとき、バリデーション違反が発生しないことを確認
   @Test
-  void 受講生詳細_受講生で適切な値を入力したときに入力チェックに異常が発生しないこと(){
+  void 受講生詳細_受講生で適切な値を入力したときに入力チェックに異常が発生しないこと() {
     Student student = new Student();
 
     //バリデーション対応項目と値
@@ -75,11 +80,11 @@ class StudentControllerTest {
   // バリデーション異常
   // Studentエンティティに不正なID（数字以外）を設定したとき、バリデーション違反が発生することを確認
   @Test
-  void 受講生詳細_受講生でIDに数字以外が入力された時に入力チェックがかかること(){
+  void 受講生詳細_受講生でIDに数字以外が入力された時に入力チェックがかかること() {
     Student student = new Student();
-        student.setId("テストです");
+    student.setId("テストです");
 
-        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
 
     Assertions.assertEquals(7, violations.size());
   }
@@ -87,8 +92,9 @@ class StudentControllerTest {
   //個別取得(正常)
   //StudentにIDとフルネームを設定し、それをテスト用に用意したdetailに返す。
   @Test
-  void 受講生詳細_IDを指定することで受講生情報が帰ること()throws Exception{
+  void 受講生詳細_IDを指定することで受講生情報が帰ること() throws Exception {
     Student student = new Student();
+
     student.setId("1");
     student.setFullname("高橋一美");
 
@@ -97,22 +103,26 @@ class StudentControllerTest {
 
     given(service.searchStudent("1")).willReturn(detail);
 
-    mockMvc.perform(get("/student/{id}","1"))
+    mockMvc.perform(get("/student/{id}", "1"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.student.id").value("1"))
         .andExpect(jsonPath("$.student.fullname").value("高橋一美"));
   }
+
   //個別取得(異常系)
+  // 存在しないIDを指定したとき、MyExceptionが発生して400が返る
   @Test
-  void 受講生詳細_存在しないIDを指定するとMyExceptionが返ること()throws Exception{
+  void 受講生詳細_存在しないIDを指定するとMyExceptionが返ること() throws Exception {
 
     given(service.searchStudent("999")).willThrow(new MyException("存在しないIDです。"));
-     mockMvc.perform(get("/student/999"))
-         .andExpect(status().isBadRequest())
-         .andExpect(content().string("存在しないIDです。"));
+    mockMvc.perform(get("/student/999"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("存在しないIDです。"));
   }
+
+  // IDの形式不正（桁数制限など）で400エラーが返ることを確認
   @Test
-  void 受講生詳細_IDが長すぎる場合は400が返ってくること()throws Exception{
+  void 受講生詳細_IDが長すぎる場合は400が返ってくること() throws Exception {
     mockMvc.perform(get("/student/9999"))
         .andExpect(status().isBadRequest());
   }
@@ -120,8 +130,10 @@ class StudentControllerTest {
   @Autowired
   private ObjectMapper objectMapper;
 
+  // 登録（正常系）
+  // 正しいStudentDetailを渡すと200 OKが返る
   @Test
-  void 受講生登録_正しい入力で登録が成功すること()throws Exception{
+  void 受講生登録_正しい入力で登録が成功すること() throws Exception {
     Student student = new Student();
 
     student.setId("1");
@@ -141,9 +153,103 @@ class StudentControllerTest {
     given(service.registerStudent(any())).willReturn(studentDetail);
 
     mockMvc.perform(post("/registerStudent")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(studentDetail)))
-        .andExpect(status().isOk());
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+            .andExpect(status().isOk());
   }
 
+  // 登録（異常系）
+  // サービス層でMyExceptionが発生した場合に400エラーが返ること
+  @Test
+  void 受講生登録_サービスでMyExceptionが発生した場合400番エラーが返ること() throws Exception {
+    Student student = new Student();
+
+    student.setId("1");
+    student.setFullname("高橋一美");
+    student.setFurigana("たかはしかずみ");
+    student.setNickname("かみ");
+    student.setEmail("takahasi@exanple.com");
+    student.setRegion("北海道");
+    student.setGender("女性");
+    student.setAge(33);
+    student.setRemark("備考");
+    student.setDeleted(false);
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    given(service.registerStudent(any())).willThrow(new MyException("登録失敗"));
+
+    mockMvc.perform(post("/registerStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(student)))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("登録失敗"));
+  }
+
+  // 更新（正常系）
+  // 正しい入力で更新が成功し、成功メッセージが返る
+  @Test
+  void 受講生更新_正しい入力で更新成功すること()throws Exception{
+    Student student = new Student();
+
+    student.setId("1");
+    student.setFullname("高橋一美");
+    student.setFurigana("たかはしかずみ");
+    student.setNickname("かみ");
+    student.setEmail("takahasi@exanple.com");
+    student.setRegion("北海道");
+    student.setGender("女性");
+    student.setAge(33);
+    student.setRemark("備考");
+    student.setDeleted(false);
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    mockMvc.perform(put("/updateStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("更新処理が成功しました。")));
+  }
+
+  // 更新（異常系）
+  // サービスで例外が発生した場合に400が返る
+  @Test
+  void 受講生更新_サービスでMyExceptionが発生した場合400番エラーが返ってくること()throws Exception{
+    Student student = new Student();
+
+    student.setId("1");
+    student.setFullname("高橋一美");
+    student.setFurigana("たかはしかずみ");
+    student.setNickname("かみ");
+    student.setEmail("takahasi@exanple.com");
+    student.setRegion("北海道");
+    student.setGender("女性");
+    student.setAge(33);
+    student.setRemark("備考");
+    student.setDeleted(false);
+
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+
+    doThrow(new MyException("更新失敗"))
+        .when(service)
+        .updateStudent(any());
+
+    mockMvc.perform(put("/updateStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("更新失敗"));
+  }
+
+  // 例外発生のシミュレーション（テスト用）
+  @Test
+  void 例外テストポイント_例外が発生して400番エラーが返ること()throws Exception{
+    mockMvc.perform(get("/exception"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("これはテスト用の例外です。"));
+  }
 }

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -127,5 +127,6 @@ class StudentServiceTest {
     // Assert（検証）: リポジトリのメソッドが正しく呼び出されたかを確認
     verify(repository).updateStudent(student);
     verify(repository).updateStudentCourse(course);
+
   }
 }

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -124,6 +124,5 @@ class StudentServiceTest {
     // Assert（検証）: リポジトリのメソッドが正しく呼び出されたかを確認
     verify(repository).updateStudent(student);
     verify(repository).updateStudentCourse(course);
-
   }
 }

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -128,5 +128,4 @@ class StudentServiceTest {
     verify(repository).updateStudent(student);
     verify(repository).updateStudentCourse(course);
   }
-
 }

--- a/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
+++ b/src/test/java/student/management/Student/Management/service/StudentServiceTest.java
@@ -60,7 +60,6 @@ class StudentServiceTest {
 
   @Test
   void 受講生の詳細検索_IDに基づいて受講生とコースを取得し詳細を返すこと() {
-
     //Arrange（準備）: モックが返す受講生とコースを定義
     Student student = new Student();
     student.setId("999");
@@ -84,7 +83,6 @@ class StudentServiceTest {
 
   @Test
   void 受講生登録_受講生と受講生コースが適切に登録されること() {
-
     //Arrange（準備）: テストの対象となる受講生と受講生コース情報を定義
     Student student = new Student();
     student.setId("999");
@@ -113,7 +111,6 @@ class StudentServiceTest {
 
   @Test
   void 受講生更新_受講生とコース情報の更新が実行されること(){
-
     // Arrange（準備）: 受講生と複数の受講生コース情報を用意
     Student student = new Student();
     StudentCourse course = new StudentCourse();


### PR DESCRIPTION
### **実装内容**

行ったこと
・受講生一覧検索、受講生詳細検索、受講生登録、受講生更新の４つのTestをServiceTestに実装

テストのスクリーンショット計4枚

<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 17 57" src="https://github.com/user-attachments/assets/7668be6f-d57a-49f9-b0a1-24540cd3f2b2" />
<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 17 14" src="https://github.com/user-attachments/assets/2f4e9e5e-5954-4375-95f9-584817ef2544" />
<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 17 00" src="https://github.com/user-attachments/assets/b3bba714-0c55-429e-b793-e390510e1677" />
<img width="1710" height="1112" alt="スクリーンショット 2025-07-15 23 16 43" src="https://github.com/user-attachments/assets/1da283ea-ada6-481f-a4f0-089409a6139f" />


工夫した点・学んだこと 
・テストコードにおけるwhenとverifyがイコールになっている点とテストだからだと思いますが、Serviceクラスとの関連性がよく見える物だったので他のTestもこんな感じなのかなと想像が膨らみました。
 ・間接的な検証を入れましたが、他にも別の記載方法があるのでは？と思い、Javaひいてはプログラムは奥が深いなと感じました。

反省点 
・前回提出時はgitignoreを消しており、不必要なファイルがたくさん含まれていた。 

改善点
・今回はgitignoreが反映されて綺麗な状態となっていると思います。

変更差分について 
・前回提出した際は、REST化進行ブランチで提出しましたが、新たなブランチ(Test進行ブランチ)にしたこととmainにマージした際の元のブランチ(REST化進行ブランチ)もStudentServiceTestの実装をした後のものだったために変更差分という変更差分が恐らくありません。理由としては強制的にPRを出すために空白の行の増減を行なったためです。